### PR TITLE
gulp bump version mgmt

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Flamite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "authors": [
     "MrPing <amsellem.jonathan@gmail.com>"
   ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
     sass = require('gulp-sass'),
+    bump = require('gulp-bump'),
     watch = require('gulp-watch'),
     clean = require('gulp-clean'),
     concat = require('gulp-concat'),
@@ -25,7 +26,7 @@ gulp.task('scripts', function() {
     .pipe(gulp.dest('./build/app/js/'))
 });
 
-gulp.task('templates', function(){
+gulp.task('templates', function() {
   return gulp.src(['./app/hbs/**/*.hbs'])
     .pipe(handlebars({
       outputType: 'browser'
@@ -43,6 +44,18 @@ gulp.task('vendor', function() {
     'bower_components/pure/pure-min.css'
   ]).pipe(gulp.dest('./build/vendor/'));
 });
+
+// Bump the version on these files
+function inc(importance) {
+  return gulp.src(['./package.json', './bower.json', './manifest.json'])
+    .pipe(bump({type: importance}))
+    .pipe(gulp.dest('./'));
+}
+
+gulp.task('bump',  function() { return inc('patch'); });
+gulp.task('patch', function() { return inc('patch'); });
+gulp.task('minor', function() { return inc('minor'); });
+gulp.task('major', function() { return inc('major'); });
 
 gulp.task('build', function() {
   return runSequence('clean', ['sass', 'templates', 'scripts', 'vendor'], function() {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Flamite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "manifest_version": 2,
   "description": "Unofficial Tinder client.",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "Flamite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "devDependencies": {
     "bower": "latest",
     "gulp": "latest",
     "gulp-clean": "latest",
     "gulp-sass": "latest",
+    "gulp-bump": "latest",
     "gulp-watch": "latest",
     "gulp-concat": "latest",
     "run-sequence": "latest",


### PR DESCRIPTION
Gulp bump - Minor improvement on the version management of this app.

![](https://slack-imgs.com/?url=http%3A%2F%2Fwww.nerdist.com%2Fwp-content%2Fuploads%2F2014%2F06%2FTyson-Boop.gif&width=400&height=275)

I've seen that you update often the version of your files and so I thought that `gulp bump` could be a good tool for you.
 
Just run `gulp bump` to increment the version on your `package/bower/manifest.json` files.
You can also use `gulp patch/minor/major` options.

Oh! And if you want to go further, take a look at this [advanced example](https://www.npmjs.com/package/gulp-tag-version#advanced-example-gulpfile-with-bumping-and-commiting) (bump the version, commit and tag your branch)